### PR TITLE
Update engines to support node >= 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prominode": "./bin/prominode.js"
   },
   "engines": {
-    "node": "^8"
+    "node": ">=8"
   },
   "author": "David M. Lee, II",
   "license": "MIT",


### PR DESCRIPTION
Prevents warnings from npm when installing this package.
Node is up to version 16 now and `^8` means only version 8.